### PR TITLE
 * KeyCaptureTogglePacket was specified as having a 1-byte subtype

### DIFF
--- a/index.html
+++ b/index.html
@@ -2693,13 +2693,13 @@
               </p>
               <h4>Payload</h4>
               <dl>
-                <dt>Subtype (byte)</dt>
+                <dt>Subtype (int)</dt>
                 <dd>
                   <p>
                     Always <code>0x11</code>.
                   </p>
                 </dd>
-                <dt>Capture (boolean, 4 bytes)</dt>
+                <dt>Capture (boolean, 1 byte)</dt>
                 <dd>
                   <p>
                     Whether this console should capture keystrokes or not. Note that because this


### PR DESCRIPTION
..unlike all other packets of the same major type. Instead, the length of the boolean was wrong
