### PR TITLE
Confirmed that the first Unknown field in the Player ship properties is

### DIFF
--- a/index.html
+++ b/index.html
@@ -3715,10 +3715,11 @@
           <section id="object-player-ship">
             <h3>Player Ship</h3>
             <dt>Bit field (6 bytes, 5 bytes before v2.3.0)</dt>
-            <dt>Unknown (bit 1.1, int)</dt>
+            <dt>Weapons target (bit 1.1, int)</dt>
             <dd>
               <p>
-                This might be the ship targeted by the weapons console.
+                The ID of the object selected by the weapons officer, or 0 if the selection was
+                cleared.
               </p>
             </dd>
             <dt>Impulse (bit 1.2, float)</dt>
@@ -3857,7 +3858,7 @@
             <dt>Science target (bit 4.7, int)</dt>
             <dd>
               <p>
-                The ID of the object selected by the science officer, or 1 if the selection was
+                The ID of the object selected by the science officer, or 0 if the selection was
                 cleared.
               </p>
             </dd>


### PR DESCRIPTION
indeed the ID of the weapons target, and that 0 means no object targeted.
Also corrected the science target field to say that 0 means nothing
targeted.  The captain target on the other hand, is different from the
others, and the page is correct in that 1 means nothing targeted.
(Tested using v2.4)

Signed-off-by: Dave Thaler dthaler@microsoft.com
